### PR TITLE
fix(website): security dependency upgrades (20 advisories)

### DIFF
--- a/docs/2026-06-01-nuxt-security-upgrade-plan.md
+++ b/docs/2026-06-01-nuxt-security-upgrade-plan.md
@@ -1,0 +1,153 @@
+# Nuxt Security Upgrade Plan — `website`
+
+**Created:** 2026-06-01
+**Status:** Planned (deferred from the 2026-06-01 dependency security PR)
+**Scope:** Clear the 31 security advisories that are gated behind a major Nuxt 3 framework
+upgrade. These were intentionally **not** fixed in the override-only security PR because each
+requires a cross-major dependency bump or a breaking framework migration.
+
+---
+
+## Why these were deferred
+
+The 2026-06-01 security PR cleared 20 advisories using `package.json` `overrides` only — no
+direct-dependency version changes — because every direct dep was left at its master version.
+That worked for transitive deps where the patched version is **same-major** (i18n runtime,
+eslint toolchain, `koa`, `cross-spawn`, `@babel/*`, `svgo`, `js-yaml`, `diff`,
+`path-to-regexp`).
+
+The remaining 31 advisories cannot be fixed that way. They fall into three coupled groups,
+all anchored to the Nuxt version:
+
+1. **Nuxt core + Vite stack** — `nuxt`, `@nuxt/kit`, `@nuxt/vite-builder`, `@nuxt/telemetry`,
+   `vite`, `vite-node`, `@vitejs/plugin-vue`, `@vitejs/plugin-vue-jsx`, `esbuild`,
+   `vite-plugin-inspect`, `vite-plugin-vue-inspector`. Patched versions are cross-major
+   (`vite` 5 → 7, `esbuild` 0.24 → 0.25) and only ship inside newer Nuxt releases.
+2. **Head management** — `unhead`, `@unhead/vue`. Nuxt ≥ 3.17 migrates `unhead` 1.x → 2.x.
+   The installed `@nuxtjs/i18n@8` imports `getActiveHead` from `unhead`, which **no longer
+   exists** in `unhead` 2.x — so bumping Nuxt past 3.16 hard-breaks the build until i18n is
+   also upgraded to v9.
+3. **DevTools download/build toolchain** — `@nuxt/devtools` (1.0.8) pulls
+   `pacote → @npmcli/run-script → node-gyp → {cacache, make-fetch-happen, npm-registry-fetch,
+   tar 6.x, @sigstore/*, sigstore, tuf-js}`, plus `giget`, `c12`, `ajv`, `devalue`, `nanoid`.
+   `tar`'s six 2026 CVEs are patched only in the 7.x line (≥ 7.5.11); the 6.x copies here
+   would need a cross-major jump. All of this is replaced wholesale by upgrading
+   `@nuxt/devtools` (which happens via the Nuxt upgrade). `parse-git-config@3.0.0` has **no
+   patched release** — it is dropped only when the newer devtools chain stops depending on it.
+
+### The cascade discovered during the security PR
+
+Bumping `nuxt` 3.10.3 → 3.21.6 (the version that clears all `nuxt` advisories) forces, in order:
+
+- **Node ≥ 22.12** — Nuxt 3.21's `oxc-walker` does `require("oxc-parser")`, and `oxc-parser`
+  is ESM-only; `require()` of an ESM package only works on Node 22.12+. The repo currently
+  builds on Node 22.11.
+- **`sass-embedded` as an explicit devDependency** — Vite 7 drops the bundled Sass compiler.
+  `assets/main.scss` then fails to build. (Note: this `.scss` build dependency is **already
+  missing on master** — see "Pre-existing build gap" below.)
+- **`@nuxtjs/i18n` 8 → 9 (breaking)** — required for `unhead` 2 compatibility; v9 has
+  breaking config and composable changes that need code updates and re-verification.
+
+---
+
+## Deferred advisories (31)
+
+Re-run `npm audit` after the upgrade to confirm each is cleared.
+
+| Severity | Package | Installed range | Cleared by |
+|---|---|---|---|
+| critical | `nuxt` | ≤ 3.21.5 | `nuxt` ≥ 3.21.6 |
+| high | `@nuxt/kit` | 3.1.0 – 3.15.4 | Nuxt upgrade |
+| high | `@nuxt/vite-builder` | ≤ 3.15.4 | Nuxt upgrade |
+| high | `@nuxt/telemetry` | ≤ 2.6.5 | Nuxt upgrade |
+| high | `@nuxt/devtools` | ≤ 2.6.3 | `@nuxt/devtools` ≥ 2.6.4 (via Nuxt) |
+| high | `devalue` | ≤ 5.6.3 | `devalue` ≥ 5.6.4 (via Nuxt/Nitro) |
+| high | `c12` | 1.1.0 – 2.0.4 | via Nuxt config loader |
+| high | `giget` | 0.0.1 – 1.2.5 | via `@nuxt/devtools` |
+| high | `node-gyp` | ≤ 10.3.1 | via `@nuxt/devtools` → `pacote` chain |
+| high | `pacote` | 5.0.0 – 21.0.0 | via `@nuxt/devtools` |
+| high | `@npmcli/run-script` | 1.1.1 – 9.0.1 | via `pacote` |
+| high | `cacache` | 14.0.0 – 18.0.4 | via `pacote` |
+| high | `make-fetch-happen` | 7.1.1 – 14.0.0 | via `pacote` |
+| high | `npm-registry-fetch` | 7.0.0 – 18.0.0 | via `pacote` |
+| high | `sigstore` | 1.6.0 – 2.3.1 | via `pacote` |
+| high | `@sigstore/sign` | ≤ 2.3.2 | via `pacote` |
+| high | `@sigstore/tuf` | ≤ 2.3.4 | via `pacote` |
+| high | `tuf-js` | ≤ 2.2.1 | via `pacote` |
+| high | `tar` | ≤ 7.5.10 | `tar` ≥ 7.5.11 (6.x consumers must move to 7.x) |
+| high | `parse-git-config` | `*` (no fix) | **No patched release** — dropped when devtools chain stops depending on it |
+| moderate | `vite` | ≤ 6.4.1 | `vite` ≥ 6.4.2 (Nuxt ships 7.x) |
+| moderate | `vite-node` | ≤ 2.2.0-beta.2 | via Nuxt/Vitest |
+| moderate | `vite-plugin-inspect` | ≤ 0.8.8 | via `@nuxt/devtools` |
+| moderate | `vite-plugin-vue-inspector` | ≤ 5.3.0 | via `@nuxt/devtools` |
+| moderate | `@vitejs/plugin-vue` | 1.8.0 – 5.2.0 | via Vite upgrade |
+| moderate | `@vitejs/plugin-vue-jsx` | ≤ 4.1.0 | via Vite upgrade |
+| moderate | `esbuild` | ≤ 0.24.2 | `esbuild` ≥ 0.25.0 (via Vite) |
+| moderate | `nanoid` | 4.0.0 – 5.0.8 | `nanoid` ≥ 5.0.9 |
+| moderate | `unhead` | ≤ 2.1.12 | `unhead` ≥ 2.1.13 (Nuxt ≥ 3.17) |
+| low | `@unhead/vue` | ≤ 2.1.10 | via `unhead` upgrade |
+| moderate | `ajv` | < 6.14.0 | via dependency tree refresh |
+
+---
+
+## Step-by-step upgrade
+
+> Run all `npm`/`node` commands with a Node **≥ 22.12** on `PATH`. Cut a fresh branch from
+> `origin/master`. The repo's global `~/.npmrc` sets `ignore-scripts=true`, so run
+> `npx nuxt prepare` manually after install, and note that native optional bindings
+> (`@oxc-parser/*`, etc.) may need an explicit `npm install --no-save <binding>` if a bulk
+> install skips them.
+
+### Stage 0 — Prerequisites (no code yet)
+1. Install/select Node ≥ 22.12 (e.g. `nvm install 22.12.0 && nvm use 22.12.0`). Pin it for
+   the repo — add `.nvmrc` (`22.12`) and bump CI's Node version in the shared
+   `cash-track/.github` build workflow.
+2. Read the upstream upgrade guides: Nuxt 3.10 → latest 3.x release notes, `@nuxtjs/i18n`
+   v8 → v9 migration, `unhead` v1 → v2, Vite 5 → 7.
+
+### Stage 1 — Build tooling
+3. Add `sass-embedded` to `devDependencies` (resolves the `assets/main.scss` build; see
+   "Pre-existing build gap"). Verify `npm run build` once it's in.
+4. Add `compatibilityDate: '2026-06-01'` to `nuxt.config.ts` (Nitro warns without it).
+
+### Stage 2 — i18n v9 (do before/with the Nuxt bump)
+5. `npm install @nuxtjs/i18n@^9` and migrate config + composables per the v9 guide
+   (option renames, `vueI18n` config path, `useI18n` usage). This is the breaking part —
+   budget real time and re-test every localized page (EN + UK).
+6. Drop the `vue-i18n` / `@intlify/*` overrides added in the security PR once i18n v9 pulls
+   patched `vue-i18n` natively (confirm with `npm ls vue-i18n @intlify/shared`).
+
+### Stage 3 — Nuxt + Vite stack
+7. `npm install nuxt@^3.21.6`. This pulls Vite 7, `unhead` 2, patched `@nuxt/devtools`,
+   `@nuxt/vite-builder`, `esbuild`, `nanoid`, `devalue`, and the refreshed `pacote`/`node-gyp`
+   chain (clears the bulk of the deferred list).
+8. `npx nuxt prepare`, then `npm run build`. Fix any Vite 7 / unhead 2 fallout
+   (CSS handling, `useHead` usage, module compatibility).
+
+### Stage 4 — Residual overrides
+9. Review the `overrides` block. Remove any now-redundant entries (the i18n group; possibly
+   `path-to-regexp`, `glob`, `minimatch` if the new tree resolves patched versions natively).
+   Keep only those still required by `npm audit`.
+10. For `tar`: confirm the new `@nuxt/devtools` chain resolves `tar` ≥ 7.5.11. If a stray 6.x
+    copy remains, add a scoped override `"tar@>=6.0.0 <7.0.0": "^7.5.11"` **only after**
+    verifying its consumers tolerate tar 7 (API/ESM change) — otherwise leave it documented.
+11. `parse-git-config`: verify it's gone from the tree. If still present with no patched
+    release, document as accepted risk (dev-only, build-time).
+
+### Stage 5 — Verification gates
+12. `npm audit` → target **0 vulnerabilities** (or only `parse-git-config` documented).
+13. `npm run lint:js` → clean.
+14. `npm run build` → succeeds.
+15. `agent-browser` smoke test of the marketing site per project CLAUDE.md: home page
+    `https://dev-cash-track.app`, language switch EN ↔ UK, all top-level routes render.
+16. Update this doc's status to "Done" and reference the upgrade PR.
+
+---
+
+## Pre-existing build gap (not introduced by the security PR)
+
+`nuxt.config.ts` imports `assets/main.scss`, but neither `sass` nor `sass-embedded` is in
+master's dependency tree (they appear only as a `"*"` optional peer in the lockfile). A clean
+`npm install && npm run build` on **master** fails with
+`Preprocessor dependency "sass-embedded" not found`. CI presumably provides it out-of-band.
+Stage 1 step 3 fixes this properly by declaring `sass-embedded` as a devDependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "@nuxtjs/eslint-config-typescript": "^12.1.0",
                 "@nuxtjs/i18n": "^8.1.1",
                 "@simplewebauthn/types": "^9.0.1",
-                "eslint": "*",
+                "eslint": "latest",
                 "nuxt-gtag": "^1.2.1"
             }
         },
@@ -162,79 +162,17 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.23.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.23.4",
-                "chalk": "^2.4.2"
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        },
-        "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@babel/compat-data": {
@@ -500,18 +438,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -526,102 +464,25 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.23.9",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
-            "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.23.9",
-                "@babel/traverse": "^7.23.9",
-                "@babel/types": "^7.23.9"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.23.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.20",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.7"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -731,12 +592,10 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-            "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -750,13 +609,14 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.23.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
-            "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.23.9",
-                "@babel/types": "^7.23.9"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -783,13 +643,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1385,10 +1245,11 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "devOptional": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1468,10 +1329,11 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "devOptional": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1583,13 +1445,14 @@
             "dev": true
         },
         "node_modules/@intlify/core": {
-            "version": "9.9.1",
-            "resolved": "https://registry.npmjs.org/@intlify/core/-/core-9.9.1.tgz",
-            "integrity": "sha512-KPD++4tB2M3TeeRqUtsSRFREVtrZHBdUzxF05zF0tbd/hZQJugJYN0t/AY1fp75OKWYZHJOKz7kKX36q8Qx7FA==",
+            "version": "9.14.5",
+            "resolved": "https://registry.npmjs.org/@intlify/core/-/core-9.14.5.tgz",
+            "integrity": "sha512-Sx/587o6NCiuY1ScV+zEkVeMhA4SWpcOAG04jADxYqXnP63dy3vsAsuUvpGoifQc/l/hNd1MoHZtMNJr2TjnIg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "9.9.1",
-                "@intlify/shared": "9.9.1"
+                "@intlify/core-base": "9.14.5",
+                "@intlify/shared": "9.14.5"
             },
             "engines": {
                 "node": ">= 16"
@@ -1599,13 +1462,14 @@
             }
         },
         "node_modules/@intlify/core-base": {
-            "version": "9.9.1",
-            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.9.1.tgz",
-            "integrity": "sha512-qsV15dg7jNX2faBRyKMgZS8UcFJViWEUPLdzZ9UR0kQZpFVeIpc0AG7ZOfeP7pX2T9SQ5jSiorq/tii9nkkafA==",
+            "version": "9.14.5",
+            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
+            "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@intlify/message-compiler": "9.9.1",
-                "@intlify/shared": "9.9.1"
+                "@intlify/message-compiler": "9.14.5",
+                "@intlify/shared": "9.14.5"
             },
             "engines": {
                 "node": ">= 16"
@@ -1631,12 +1495,13 @@
             }
         },
         "node_modules/@intlify/message-compiler": {
-            "version": "9.9.1",
-            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.9.1.tgz",
-            "integrity": "sha512-zTvP6X6HeumHOXuAE1CMMsV6tTX+opKMOxO1OHTCg5N5Sm/F7d8o2jdT6W6L5oHUsJ/vvkGefHIs7Q3hfowmsA==",
+            "version": "9.14.5",
+            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
+            "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@intlify/shared": "9.9.1",
+                "@intlify/shared": "9.14.5",
                 "source-map-js": "^1.0.2"
             },
             "engines": {
@@ -1647,10 +1512,11 @@
             }
         },
         "node_modules/@intlify/shared": {
-            "version": "9.9.1",
-            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.9.1.tgz",
-            "integrity": "sha512-b3Pta1nwkz5rGq434v0psHwEwHGy1pYCttfcM22IE//K9owbpkEvFptx9VcuRAxjQdrO2If249cmDDjBu5wMDA==",
+            "version": "9.14.5",
+            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
+            "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 16"
             },
@@ -2132,32 +1998,33 @@
             }
         },
         "node_modules/@npmcli/package-json/node_modules/glob": {
-            "version": "10.3.10",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@npmcli/package-json/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -3798,14 +3665,6 @@
                 "vue": "^2.7.0 || ^3.0.0"
             }
         },
-        "node_modules/@trysound/sax": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
         "node_modules/@tufjs/canonical-json": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -3827,11 +3686,12 @@
             }
         },
         "node_modules/@tufjs/models/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -4060,12 +3920,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -4885,21 +4746,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/archiver-utils/node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
         "node_modules/archiver-utils/node_modules/minimatch": {
             "version": "9.0.9",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -5492,21 +5338,21 @@
             }
         },
         "node_modules/cacache/node_modules/glob": {
-            "version": "10.3.10",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -5521,11 +5367,12 @@
             }
         },
         "node_modules/cacache/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5958,9 +5805,10 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -6414,9 +6262,10 @@
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
         },
         "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -7118,10 +6967,11 @@
             }
         },
         "node_modules/eslint-plugin-import/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7175,10 +7025,11 @@
             }
         },
         "node_modules/eslint-plugin-n/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7261,10 +7112,11 @@
             }
         },
         "node_modules/eslint-plugin-node/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7503,10 +7355,11 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "devOptional": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -8538,11 +8391,12 @@
             }
         },
         "node_modules/ignore-walk/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -9121,14 +8975,12 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
         "node_modules/jackspeak": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-            "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -9157,13 +9009,25 @@
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "devOptional": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -9304,9 +9168,10 @@
             "license": "MIT"
         },
         "node_modules/koa": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.0.tgz",
-            "integrity": "sha512-KEL/vU1knsoUvfP4MC4/GthpQrY/p6dzwaaGI6Rt4NQuFqkw3qrvsdYF5pz3wOfi7IGTvMPHC9aZIcUKYFNxsw==",
+            "version": "2.16.4",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+            "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
+            "license": "MIT",
             "dependencies": {
                 "accepts": "^1.3.5",
                 "cache-content-type": "^1.0.0",
@@ -11347,21 +11212,21 @@
             }
         },
         "node_modules/node-gyp/node_modules/glob": {
-            "version": "10.3.10",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -11376,11 +11241,12 @@
             }
         },
         "node_modules/node-gyp/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -12216,9 +12082,10 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+            "license": "MIT"
         },
         "node_modules/path-type": {
             "version": "5.0.0",
@@ -13169,32 +13036,33 @@
             }
         },
         "node_modules/read-package-json/node_modules/glob": {
-            "version": "10.3.10",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/read-package-json/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -13406,11 +13274,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        },
         "node_modules/regexp-tree": {
             "version": "0.1.27",
             "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -13496,9 +13359,10 @@
             }
         },
         "node_modules/replace-in-file/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -13663,10 +13527,11 @@
             }
         },
         "node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "devOptional": true,
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -13850,6 +13715,15 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "optional": true
+        },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/scule": {
             "version": "1.3.0",
@@ -14495,32 +14369,33 @@
             }
         },
         "node_modules/sucrase/node_modules/glob": {
-            "version": "10.3.10",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.5",
-                "minimatch": "^9.0.1",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                "path-scurry": "^1.10.1"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/sucrase/node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -14557,17 +14432,18 @@
             "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
         },
         "node_modules/svgo": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
-            "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+            "license": "MIT",
             "dependencies": {
-                "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^5.1.0",
                 "css-tree": "^2.3.1",
                 "css-what": "^6.1.0",
                 "csso": "^5.0.5",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.0.0",
+                "sax": "^1.5.0"
             },
             "bin": {
                 "svgo": "bin/svgo"
@@ -14755,9 +14631,11 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-            "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
             "dependencies": {
                 "chownr": "^2.0.0",
                 "fs-minipass": "^2.0.0",
@@ -16391,9 +16269,10 @@
             }
         },
         "node_modules/vscode-languageclient/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -16494,13 +16373,15 @@
             }
         },
         "node_modules/vue-i18n": {
-            "version": "9.9.1",
-            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.9.1.tgz",
-            "integrity": "sha512-xyQ4VspLdNSPTKBFBPWa1tvtj+9HuockZwgFeD2OhxxXuC2CWeNvV4seu2o9+vbQOyQbhAM5Ez56oxUrrnTWdw==",
+            "version": "9.14.5",
+            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
+            "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+            "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "9.9.1",
-                "@intlify/shared": "9.9.1",
+                "@intlify/core-base": "9.14.5",
+                "@intlify/shared": "9.14.5",
                 "@vue/devtools-api": "^6.5.0"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,23 @@
         "@simplewebauthn/types": "^9.0.1",
         "eslint": "latest",
         "nuxt-gtag": "^1.2.1"
+    },
+    "overrides": {
+        "vue-i18n": "^9.14.5",
+        "@intlify/core": "^9.14.5",
+        "@intlify/core-base": "^9.14.5",
+        "@intlify/message-compiler": "^9.14.5",
+        "@intlify/shared": "^9.14.5",
+        "@babel/runtime": "^7.26.10",
+        "@babel/helpers": "^7.26.10",
+        "cross-spawn": "^7.0.6",
+        "koa": "^2.16.4",
+        "minimatch@<3.1.4": "^3.1.4",
+        "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
+        "glob@>=10.2.0 <10.5.0": "^10.5.0",
+        "svgo@>=3.0.0 <3.3.3": "^3.3.3",
+        "js-yaml@>=4.0.0 <4.1.1": "^4.1.1",
+        "diff@>=5.0.0 <5.2.2": "^5.2.2",
+        "path-to-regexp@>=4.0.0 <6.3.0": "^6.3.0"
     }
 }


### PR DESCRIPTION
## Security dependency upgrades — `website`

Source of findings: **Dependabot** (55 open alerts; 51 reproduced by `npm audit` against the
master tree). This PR clears **20 advisories** using `package.json` `overrides` only — every
direct dependency stays at its master version (no `nuxt`, `@nuxt/ui`, or `@nuxtjs/i18n` bump),
keeping the blast radius to security pins.

| Severity | Package | From → To | CVE / GHSA |
|---|---|---|---|
| critical | `koa` | 2.15.0 → 2.16.4 | CVE-2025-25200, CVE-2026-27959, CVE-2025-32379, CVE-2025-8129 |
| high | `vue-i18n` | 9.x → 9.14.5 | CVE-2025-27597, CVE-2025-53892, CVE-2024-52810, CVE-2024-52809 |
| high | `minimatch` | 3.1.2 → 3.1.4, 9.0.3 → 9.0.7 | CVE-2026-27903, CVE-2026-27904, CVE-2026-26996 |
| high | `glob` | 10.3.10 → 10.5.0 | CVE-2025-64756 |
| high | `cross-spawn` | 7.0.3 → 7.0.6 | CVE-2024-21538 |
| high | `path-to-regexp` | 6.2.1 → 6.3.0 | CVE-2024-45296 |
| high | `svgo` | 3.2.0 → 3.3.3 | CVE-2026-29074 |
| moderate | `@intlify/core`, `core-base`, `message-compiler`, `shared` | 9.9.1 → 9.14.5 | CVE-2025-53892, CVE-2024-52809 |
| moderate | `@babel/runtime`, `@babel/helpers` | 7.x → 7.26.10 / 7.29.7 | CVE-2025-27789 |
| moderate | `js-yaml` | 4.1.0 → 4.1.1 | CVE-2025-64718 |
| low | `diff` | 5.2.0 → 5.2.2 | CVE-2026-24001 |

Bumping `minimatch` also resolved the `@typescript-eslint/*` cluster (their only vulnerable
path was a nested `minimatch`).

### What changed
- Added a `package.json` `overrides` block. **Bare** overrides for confirmed single-major
  packages (reliable); **version-range-scoped** overrides for multi-major packages
  (`minimatch`, `glob`) and packages with other-major consumers in the wild (`svgo`,
  `js-yaml`, `diff`, `path-to-regexp`) so safe major lines are left untouched.
- No direct-dependency version changes; `nuxt`/`@nuxt/ui`/`@nuxtjs/i18n` unchanged.

### Codebase changes (if any)
- None — dependency override pins only. Plus `docs/2026-06-01-nuxt-security-upgrade-plan.md`
  documenting the deferred work.

### Verification
- `npm audit` → 51 → **31** (the 20 above cleared; resolved versions confirmed via `npm ls`).
- `npm run lint:js` → clean (exit 0).
- `npm run build` → succeeds. **Note:** the build requires `sass-embedded`, which is **not
  declared on master** (`assets/main.scss` has no Sass compiler in the dep tree) — a
  pre-existing gap, not introduced here. Build was verified with `sass-embedded` present;
  the proper fix (declaring it) is the first step of the deferred plan.

### Deferred / no fix available
The remaining **31** advisories are gated behind a **major Nuxt 3 upgrade** and are tracked
in `docs/2026-06-01-nuxt-security-upgrade-plan.md`:
- **Nuxt core + Vite stack** (`nuxt`, `@nuxt/kit`, `@nuxt/vite-builder`, `vite`, `esbuild`,
  `@vitejs/*`, `vite-node`, `vite-plugin-*`) — cross-major, ship only inside newer Nuxt.
- **Head** (`unhead`, `@unhead/vue`) — 1.x → 2.x; forces `@nuxtjs/i18n` 8 → 9 (breaking).
- **DevTools toolchain** (`@nuxt/devtools` → `pacote` → `node-gyp` → `cacache`,
  `make-fetch-happen`, `npm-registry-fetch`, `tar`, `@sigstore/*`, `sigstore`, `tuf-js`,
  `giget`, `c12`, `ajv`, `devalue`, `nanoid`).
- `parse-git-config@3.0.0` — **no patched release exists**; dropped only when the newer
  devtools chain stops depending on it.

The full Nuxt bump also requires Node ≥ 22.12 and `sass-embedded` — see the plan for the
ordered, gated steps.