### PR TITLE
fix(website): upgrade simplewebauthn/browser to fix passkey login

### DIFF
--- a/api/passkey.ts
+++ b/api/passkey.ts
@@ -1,11 +1,11 @@
-import type { PublicKeyCredentialRequestOptions } from '@simplewebauthn/types'
+import type { AuthenticationResponseJSON, PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/browser'
 import type { LoginResponseInterface } from '@/api/login'
 import { useApi } from '@/api/api'
 
 export interface PasskeyInitResponseInterface {
     challenge: string
     data: string
-    dataDecoded: PublicKeyCredentialRequestOptions
+    dataDecoded: PublicKeyCredentialRequestOptionsJSON
 }
 
 export function passkeyInit(
@@ -30,7 +30,7 @@ export function passkeyInit(
 
 export function passkeyLogin(
     challenge: string,
-    data: object,
+    data: AuthenticationResponseJSON,
     captchaChallenge: string
 ): Promise<LoginResponseInterface> {
     return useApi<LoginResponseInterface>(

--- a/components/Auth/Login.vue
+++ b/components/Auth/Login.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Form, FormSubmitEvent } from '#ui/types'
-import type { AuthenticationResponseJSON } from '@simplewebauthn/types'
+import type { AuthenticationResponseJSON } from '@simplewebauthn/browser'
 import { useReCaptcha } from 'vue-recaptcha-v3'
 import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser'
 import { onMounted, ref, useI18n, useLocalePath, useRuntimeConfig } from '#imports'
@@ -198,7 +198,7 @@ async function loginWithPasskey() {
     let authResponse: AuthenticationResponseJSON
 
     try {
-        authResponse = await startAuthentication(initResponse)
+        authResponse = await startAuthentication({ optionsJSON: initResponse.dataDecoded })
     } catch (error) {
         passkeyLoader.setLoaded()
         messager.dispatchError(error)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "dependencies": {
                 "@nuxt/ui": "^2.22.3",
                 "@pinia/nuxt": "^0.5.1",
-                "@simplewebauthn/browser": "^9.0.1",
+                "@simplewebauthn/browser": "^13.3.0",
                 "@types/google.accounts": "^0.0.14",
                 "@types/js-cookie": "^3.0.6",
                 "js-cookie": "^3.0.7",
@@ -22,7 +22,6 @@
             "devDependencies": {
                 "@nuxtjs/eslint-config-typescript": "^12.1.0",
                 "@nuxtjs/i18n": "^9.5.6",
-                "@simplewebauthn/types": "^9.0.1",
                 "eslint": "latest",
                 "nuxt-gtag": "^1.2.1",
                 "sass-embedded": "^1.100.0"
@@ -6587,19 +6586,9 @@
             }
         },
         "node_modules/@simplewebauthn/browser": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-9.0.1.tgz",
-            "integrity": "sha512-wD2WpbkaEP4170s13/HUxPcAV5y4ZXaKo1TfNklS5zDefPinIgXOpgz1kpEvobAsaLPa2KeH7AKKX/od1mrBJw==",
-            "license": "MIT",
-            "dependencies": {
-                "@simplewebauthn/types": "^9.0.1"
-            }
-        },
-        "node_modules/@simplewebauthn/types": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-9.0.1.tgz",
-            "integrity": "sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+            "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
             "license": "MIT"
         },
         "node_modules/@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@nuxt/ui": "^2.22.3",
         "@pinia/nuxt": "^0.5.1",
-        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/browser": "^13.3.0",
         "@types/google.accounts": "^0.0.14",
         "@types/js-cookie": "^3.0.6",
         "js-cookie": "^3.0.7",
@@ -28,7 +28,6 @@
     "devDependencies": {
         "@nuxtjs/eslint-config-typescript": "^12.1.0",
         "@nuxtjs/i18n": "^9.5.6",
-        "@simplewebauthn/types": "^9.0.1",
         "eslint": "latest",
         "nuxt-gtag": "^1.2.1",
         "sass-embedded": "^1.100.0"


### PR DESCRIPTION
## Problem statement

Passkey login on the website has two independent bugs:

1. `@simplewebauthn/browser` 9.0.1's `startAuthentication`/`startRegistration` UTF8-encode/decode the credential user handle instead of base64url-decoding/encoding it. This round-trips correctly only for a credential both registered and authenticated entirely under v9.0.1 — any credential registered by a current (v13) client 400s on login with "Invalid user handle".
2. `Login.vue` passed the whole `PasskeyInitResponseInterface` wrapper object into `startAuthentication()` instead of its `.dataDecoded` payload. This silently dropped `rpId`, `allowCredentials`, `userVerification`, and `extensions`, falling back to lenient browser defaults instead of the server's actual ceremony requirements.

Fixing only these two bugs would have made login fail for 100% of users, since the client would then correctly start forwarding a login options object that the API attaches an invalid `credProps` extension to (browsers reject it with `NotSupportedError`) — see the companion `api` PR, which fixes that independently pre-existing bug.

## Changes

- Upgraded `@simplewebauthn/browser` 9.0.1 → 13.3.0; removed `@simplewebauthn/types` (types now ship from the main package).
- `Login.vue`: `startAuthentication({ optionsJSON: initResponse.dataDecoded })` per the v13 API, instead of passing the whole response wrapper.
- `api/passkey.ts`: updated types to the v13-native `PublicKeyCredentialRequestOptionsJSON` / `AuthenticationResponseJSON`, removing the now-unavailable `@simplewebauthn/types` import.

## Verification

- Production build and lint pass clean.
- End-to-end: verified with direct browser-level instrumentation (`navigator.credentials.get` call args/resolution) that the ceremony now receives the server's real `rpId`/`allowCredentials`/`userVerification`, and — paired with the `api` fix — resolves successfully and completes login.
- Full Playwright E2E suite (PK-01 registration, PK-02 website login) passes against the live local stack — see the `frontend` PR (S23 / issue #130) for the added coverage.