### PR TITLE
fix(website): correct decoded passkey options generic type

### DIFF
--- a/api/passkey.ts
+++ b/api/passkey.ts
@@ -21,7 +21,7 @@ export function passkeyInit(
             credentials: 'include'
         }
     ).then((res) => {
-        res.dataDecoded = decode<PublicKeyCredentialRequestOptions>(
+        res.dataDecoded = decode<PublicKeyCredentialRequestOptionsJSON>(
             res.data
         )
         return res


### PR DESCRIPTION
## Problem statement

`passkeyInit()` decoded the server response with `decode<PublicKeyCredentialRequestOptions>(...)` — the DOM-ambient WebAuthn type, whose fields (e.g. `challenge`) are binary `BufferSource`. That value was then assigned to `PasskeyInitResponseInterface.dataDecoded`, which is declared as `PublicKeyCredentialRequestOptionsJSON` (the JSON-safe type from `@simplewebauthn/browser`, `challenge: Base64URLString`). The two types are structurally incompatible, which surfaced as a TypeScript inconsistent-type warning on the assignment.

## Changes

- `api/passkey.ts`: changed the generic type argument on the `decode()` call from `PublicKeyCredentialRequestOptions` to `PublicKeyCredentialRequestOptionsJSON`, matching the interface field's declared type and `decode()`'s actual output (`JSON.parse(atob(data))`, always JSON-safe). Also matches the only consumer — `startAuthentication({ optionsJSON })` in `Login.vue` requires exactly `PublicKeyCredentialRequestOptionsJSON`.

## Verification

- The generic type parameter has no runtime effect (TypeScript generics are erased at compile time; `decode()`'s body is unchanged), so this is a type-only correction with no behavioral change.
- Confirmed against the `@simplewebauthn/browser` type declarations that `PublicKeyCredentialRequestOptionsJSON` is the type `startAuthentication`'s `optionsJSON` parameter actually requires.
- `npm run lint` — clean.