### PR TITLE
fix(website): stop npm ci failing on dependabot lockfile updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2095,28 +2095,6 @@
                 }
             }
         },
-        "node_modules/@nuxt/cli/node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@nuxt/cli/node_modules/commander": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
-            "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=22.12.0"
-            }
-        },
         "node_modules/@nuxt/devalue": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
         "@unhead/vue": "^3.2.1",
         "fontless": {
             "esbuild": "^0.28.1"
+        },
+        "@bomb.sh/tab": {
+            "cac": "^7.0.0",
+            "commander": "^11.1.0"
         }
     }
 }


### PR DESCRIPTION
Every dependabot PR fails the `quality / Lint` job at the install step, before a single check runs — see #86:

```
npm ci` can only install packages when your package.json and package-lock.json are in sync
Missing: cac@6.7.14 from lock file
Missing: commander@15.0.0 from lock file
```

## Root cause

`@bomb.sh/tab` — a shell-completion helper pulled in by `@nuxt/cli` — declares three **optional peer dependencies**:

| Peer | Range | Hoisted | Satisfied? |
|---|---|---|---|
| `citty` | `^0.1.6 \|\| ^0.2.0` | 0.2.2 | yes |
| `cac` | `^6.7.14` | 7.0.0 (from `@eslint/config-inspector`, `vite-node`) | **no** |
| `commander` | `^13.1.0 \|\| ^14.0.0 \|\| ^15.0.0` | 11.1.0 (from `svgo`) | **no** |

npm satisfies the two unmet peers by installing nested copies under `@nuxt/cli/node_modules/`. Dependabot's resolver doesn't reproduce those nested copies when it refreshes the lockfile, so the lock it commits fails the consistency check `npm ci` performs. Nothing about the bumped dependency matters — it happens on every dependabot PR regardless of what's being updated.

This is the same failure that hit #85 mid-review, and the same class of problem the `svgo > commander: ^13.1.0` override in the 2026-06 upgrade was papering over.

## Fix

Override the two ranges to what's already hoisted, so no nested copies are needed at all:

```json
"@bomb.sh/tab": {
    "cac": "^7.0.0",
    "commander": "^11.1.0"
}
```

The resolved tree is then identical whether the lock is generated by npm locally, by CI, or by dependabot — the divergence that causes the failure can't arise.

**This is inert at runtime.** `@nuxt/cli` imports only `@bomb.sh/tab/citty` (verified: it's the sole `@bomb.sh/tab` specifier anywhere in `@nuxt/cli/dist/`). The package ships separate `cac.mjs` / `commander.mjs` / `citty.mjs` adapters and only the citty one is ever loaded, so the cac and commander peer ranges describe code this project never executes.

## Verification

Reproduced the dependabot condition directly: pruned the two nested entries from the lockfile — exactly the shape dependabot commits — then confirmed

- `npm ci --dry-run` passes (it failed on this same lock before the override), and
- `npm install` does **not** re-add the nested copies, so the lock is stable.

Also confirmed against #86's actual branch: applying the override to its lockfile makes `npm ci --dry-run` pass.

`npm run lint:js`, `npm run typecheck` and `npm run build` all pass. The lockfile diff is 22 lines — the two nested entries removed, nothing else added or changed.

Once this lands, #86 needs a `@dependabot rebase` to pick it up.
