### PR TITLE
feat(website): display release tag and git sha in footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,13 @@ RUN npm ci
 
 ADD . ${APP_ROOT}
 
+# Release metadata shown in the footer. Nuxt reads NUXT_PUBLIC_* from the environment at
+# server start, so these ENV values flow into runtimeConfig.public without a rebuild.
+ARG GIT_TAG=""
+ARG GIT_COMMIT=""
+ENV NUXT_PUBLIC_APP_VERSION=${GIT_TAG}
+ENV NUXT_PUBLIC_APP_COMMIT=${GIT_COMMIT}
+
 RUN npm ci && npm run build
 
 CMD ["node", "/web/.output/server/index.mjs"]

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMAGE_LATEST=$(REPO):latest
 .PHONY: build tag push start stop
 
 build:
-	docker build . -t $(IMAGE_DEV)
+	docker build . -t $(IMAGE_DEV) --build-arg GIT_TAG=$(RELEASE_VERSION) --build-arg GIT_COMMIT=$(shell git rev-parse HEAD)
 
 tag:
 	docker tag $(IMAGE_DEV) $(IMAGE_RELEASE)

--- a/app/components/Footer.vue
+++ b/app/components/Footer.vue
@@ -4,6 +4,28 @@
             <div class="sm:flex items-start">
                 <div class="sm:basis-1/3 sm:text-left text-center">
                     © {{ year }} Cash Track
+                    <template v-if="release.hasReleaseTag">
+                        ·
+                        <ULink
+                            class="link"
+                            :to="release.versionHref"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {{ release.version }}
+                        </ULink>
+                    </template>
+                    <template v-if="release.hasCommit">
+                        ·
+                        <ULink
+                            class="link"
+                            :to="release.commitHref"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {{ release.shortCommit }}
+                        </ULink>
+                    </template>
                 </div>
                 <div
                     class="sm:basis-1/3 text-center"
@@ -45,9 +67,11 @@
 
 <script setup lang="ts">
 import TgIcon from '@/components/Shared/TgIcon.vue'
+import { useReleaseInfo } from '@/lib/ReleaseInfo'
 
 const year = new Date().getFullYear()
 const localePath = useLocalePath()
+const release = useReleaseInfo()
 </script>
 
 <style>

--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -5,7 +5,7 @@
                 <div class="navbar-mobile-head">
                     <ULink
                         class="logo-link"
-                        to="/"
+                        :to="localePath('/')"
                     >
                         <Logo />
                     </ULink>
@@ -24,7 +24,7 @@
                         <div class="navbar-main">
                             <ULink
                                 class="logo-link"
-                                to="/"
+                                :to="localePath('/')"
                             >
                                 <Logo />
                             </ULink>
@@ -319,7 +319,7 @@ function applyProfileLocale(profileLocale: string) {
 function onLogout() {
     logout().finally(() => {
         authStore.logout()
-        router.push('/')
+        router.push(localePath('/'))
     })
 }
 

--- a/app/lib/ReleaseInfo.ts
+++ b/app/lib/ReleaseInfo.ts
@@ -1,0 +1,41 @@
+import { useRuntimeConfig } from '#app'
+
+export interface ReleaseInfoInterface {
+    version: string
+    hasReleaseTag: boolean
+    hasCommit: boolean
+    shortCommit: string
+    versionHref: string
+    commitHref: string
+}
+
+// Snapshot builds pass a branch name (e.g. "master") as appVersion, not a release tag —
+// only treat it as one when it looks like one (e.g. "v2.0.5").
+const releaseTagPattern = /^v\d/
+
+function releaseTagLink(tag: string): string {
+    return `https://github.com/cash-track/website/releases/tag/${tag}`
+}
+
+function commitLink(sha: string): string {
+    return `https://github.com/cash-track/website/commit/${sha}`
+}
+
+export function useReleaseInfo(): ReleaseInfoInterface {
+    const config = useRuntimeConfig()
+
+    const version = config.public.appVersion
+    const commit = config.public.appCommit
+    const hasReleaseTag = releaseTagPattern.test(version)
+
+    return {
+        version,
+        hasReleaseTag,
+        hasCommit: commit.length > 0,
+        shortCommit: commit.slice(0, 7),
+        versionHref: releaseTagLink(version),
+        // With a release tag both the tag and the sha link to the same release page;
+        // without one the sha links to its own commit page.
+        commitHref: hasReleaseTag ? releaseTagLink(version) : commitLink(commit)
+    }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script setup lang="ts">
-import { useHead, defineI18nRoute, useLocalePath, useI18n, computed } from '#imports'
+import { useHead, useLocalePath, useI18n, computed } from '#imports'
 import { useWebAppLinks } from '@/lib/WebAppLinks'
 import { useAuthStore } from '@/store/auth'
 import TgIcon from '@/components/Shared/TgIcon.vue'
@@ -126,7 +126,6 @@ useHead({
     title: t('home.title'),
     meta: [{ property: 'og:title', content: t('home.title') }]
 })
-defineI18nRoute(false)
 
 const isLogged = computed(() => auth.isLogged)
 const isProfileLoading = computed(() => auth.isProfileLoading)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -115,7 +115,9 @@ export default defineNuxtConfig({
             webAppUrl: process.env.NUXT_PUBLIC_WEB_APP_URL,
             gatewayUrl: process.env.NUXT_PUBLIC_GATEWAY_URL,
             googleClientId: process.env.NUXT_PUBLIC_GOOGLE_CLIENT_ID,
-            captchaClientKey: process.env.NUXT_PUBLIC_CAPTCHA_CLIENT_KEY
+            captchaClientKey: process.env.NUXT_PUBLIC_CAPTCHA_CLIENT_KEY,
+            appVersion: process.env.NUXT_PUBLIC_APP_VERSION ?? '',
+            appCommit: process.env.NUXT_PUBLIC_APP_COMMIT ?? ''
         }
     },
     devServer: {


### PR DESCRIPTION
Closes #89. Mirrors cash-track/frontend#124.

## Problem statement

Nothing on the site identified which revision was actually being served, so a cached page could not be told apart from a fresh deployment.

While verifying that change, a second, unrelated bug surfaced: `/uk` and `/uk/` returned 404. The Ukrainian home page was unreachable, while every other localized route (`/uk/about`, `/uk/help`, `/uk/login`, …) worked. The user-visible symptom was worse than a bad URL — the header switches language through `setLocale()`, which under `prefix_except_default` navigates to the localized route, so on the home page it had nothing to navigate to and picking Ukrainian did nothing at all. Both are fixed here.

## Changes

**Footer revision info (#89).** The copyright line now reads `© 2026 Cash Track · v2.0.5 · 5009cb0`, with the tag and short sha linking to the GitHub release page.

The values flow from the `GIT_TAG`/`GIT_COMMIT` Docker build args — already sent by the shared CI build workflow, this Dockerfile was simply ignoring them — into `ENV`, and are read through Nuxt's `runtimeConfig.public`, which resolves `NUXT_PUBLIC_*` from the environment at server start. This deliberately does not port the SPA's `window.__APP_CONFIG__`/`entrypoint.sh` `sed` mechanism: that exists because the frontend ships as static files behind nginx, whereas this site runs a node SSR server that reads the environment natively.

Both new `runtimeConfig` keys default to `''` rather than `undefined`. An `undefined` default is dropped from the schema at build time, which silently removes the ability to override it via `NUXT_PUBLIC_*` at runtime.

Snapshot builds pass a branch name as the tag, so a value only counts as a release tag when it looks like one (`/^v\d/`); otherwise the sha alone renders, linked to its commit page. Local dev sets neither var and shows the plain copyright line.

`make build` passes the two build args so a locally built image is stamped the same way. `make start` is deliberately left alone — it does `include .env`, which has no such vars, so an empty `-e` would clobber the ENV baked into the image.

**Ukrainian home page route.** `app/pages/index.vue` called `defineI18nRoute(false)`, which opts a page out of localized route generation. The call arrived in 661b518 ("Nuxt 3 upgrade with NuxtUI and Tailwind") replacing the old class-component body, carries no comment, and looks incidental to that migration: the page is fully translated and the site ships a language switcher, so having no Ukrainian home page was not intended.

Three hardcoded unprefixed home references in the header were safe only while `/` had no alternate, and would now drop a Ukrainian visitor onto the English home page: both logo links and the post-logout redirect. They go through `localePath()`, matching the path-form calls already used elsewhere in that component.

`/en` still returns 404, which is correct — `prefix_except_default` leaves the default locale unprefixed by design.

## Verification

Each change was independently reviewed and browser-verified against the production build (`node .output/server/index.mjs` with real env vars — the actual deployed code path, not `nuxt dev`).

Footer, all three render states:

- `v2.0.5` + sha → `© 2026 Cash Track · v2.0.5 · 5009cb0`, both links to `/releases/tag/v2.0.5`, `target="_blank" rel="noopener noreferrer"`.
- `master` + sha → `© 2026 Cash Track · 5009cb0`, exactly one separator, no branch name shown, sha linked to `/commit/<full sha>` with a 7-char label.
- Neither set → plain `© 2026 Cash Track`, no separator, no links, no `undefined`.

Also checked on a second page, at 375×812 (no overflow), and in dark mode (links legible, same green as the policy links).

Route fix:

- Build artifacts confirm the cause and the fix — the generated `disabledI18nPathToPath` map goes from `{ "/": "/" }` to `{}`, and a `/uk` route literal now appears alongside the other localized routes.
- `/uk` → 200, `lang="uk-UA"`, Ukrainian copy; `/` → 200, English; `/en` → 404 as expected.
- Language switcher confirmed in both directions from the home page: `/` → Ukrainian → `/uk`, and `/uk` → English → `/`. Also `/uk/about` → English → `/about`, guarding against a regression on pages that already worked.
- Header logo from `/uk/about` lands on `/uk`, desktop and mobile.
- Footer revision info renders identically on `/uk`, confirming it is locale-independent.
- Console clean on `/`, `/uk` and `/uk/about`, with no hydration mismatch warnings.

`npm run lint:js`, `npm run typecheck` and `npm run build` pass on both commits.

This repo has no test framework, so there are no unit or E2E tests to add here; the browser matrix above is the gate.