### PR TITLE
feat(website): seed the header from the shared profile cookie

### DIFF
--- a/app/api/profile.ts
+++ b/app/api/profile.ts
@@ -4,7 +4,7 @@ export interface ProfileInterface {
     id: number
     name: string
     email: string
-    lastName: string
+    lastName: string | null
     nickName: string
     isEmailConfirmed: boolean
     photoUrl: string | null

--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -196,8 +196,10 @@
 <script setup lang="ts">
 import type { DropdownMenuItem } from '@nuxt/ui'
 import type { LocaleObject } from '@nuxtjs/i18n'
+import { FetchError } from 'ofetch'
 import { useLocalePath, useI18n, useColorMode, onMounted, useRouter, useRequestHeaders, useState, computed, ref } from '#imports'
 import { readCookieValue } from '@/utils/cookies'
+import { parseCachedProfile } from '@/utils/profileCookie'
 import { useWebAppLinks } from '@/lib/WebAppLinks'
 import { useAuthStore } from '@/store/auth'
 import { profileGet, profilePutLocale, type ProfileInterface } from '@/api/profile'
@@ -289,6 +291,18 @@ const isFreshVisitor = useState('ct-fresh-visitor-locale', () => {
     return readCookieValue(cookieHeader, 'cshtrkl') === null
 })
 
+// Same SSR-resolve-once/hydrate pattern as isFreshVisitor above: parsing cshtrkp from the
+// request's Cookie header lets the header render signed-in on first paint (#147).
+const cachedProfile = useState('ct-cached-profile', () => {
+    const cookieHeader = useRequestHeaders(['cookie']).cookie ?? ''
+    return parseCachedProfile(cookieHeader)
+})
+
+const initialCachedProfile = cachedProfile.value
+if (initialCachedProfile) {
+    authStore.seedFromCache(initialCachedProfile)
+}
+
 onMounted(() => {
     loadProfile()
 })
@@ -297,8 +311,15 @@ function loadProfile() {
     profileGet().then((response) => {
         authStore.login(response.data)
         applyProfileLocale(response.data.locale)
-    }).catch(() => {
-        authStore.logout()
+    }).catch((error) => {
+        // Only a 401 proves the session is dead (the gateway's refresh failed) and may clear
+        // the cache. Anything else is transient — reset() drops the UI state, not the cookie.
+        if (error instanceof FetchError && error.statusCode === 401) {
+            authStore.logout()
+        }
+        else {
+            authStore.reset()
+        }
     })
 }
 

--- a/app/plugins/shared-cookies.client.ts
+++ b/app/plugins/shared-cookies.client.ts
@@ -1,52 +1,13 @@
 // `@nuxtjs/color-mode`/`@nuxtjs/i18n`'s cookies are host-only (build-time config can't carry a `domain` — one image, configured per-env at runtime).
 // This plugin re-scopes `cshtrkt` and `cshtrkl` to the parent domain so the frontend SPA can share them.
 // Only one cookie of each name may exist at rest, or the pre-paint theme parser breaks — the host-only one is deleted first.
-import { useRuntimeConfig, useColorMode, watch, nextTick } from '#imports'
+import { useColorMode, watch, nextTick } from '#imports'
 import { readCookieValue } from '@/utils/cookies'
+import { parentDomain, deleteHostOnlyCookie, writeSharedCookie } from '@/utils/sharedCookie'
 
 const THEME_COOKIE = 'cshtrkt'
 const LOCALE_COOKIE = 'cshtrkl'
 const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
-
-function parentDomain(): string | null {
-    const config = useRuntimeConfig()
-    const candidates = [config.public.baseUrl, window.location.origin]
-
-    for (const candidate of candidates) {
-        if (!candidate) {
-            continue
-        }
-
-        try {
-            return new URL(candidate).hostname
-        }
-        catch {
-            continue
-        }
-    }
-
-    return null
-}
-
-function deleteHostOnlyCookie(name: string) {
-    document.cookie = `${name}=; path=/; max-age=0`
-}
-
-function writeDomainCookie(name: string, value: string, domain: string) {
-    const attrs = [
-        `${name}=${encodeURIComponent(value)}`,
-        `Domain=.${domain}`,
-        'path=/',
-        `max-age=${COOKIE_MAX_AGE}`,
-        'SameSite=Lax'
-    ]
-
-    if (window.location.protocol === 'https:') {
-        attrs.push('Secure')
-    }
-
-    document.cookie = attrs.join('; ')
-}
 
 export default defineNuxtPlugin((nuxtApp) => {
     const colorMode = useColorMode()
@@ -59,7 +20,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
     function sync(name: string, value: string) {
         deleteHostOnlyCookie(name)
-        writeDomainCookie(name, value, domain as string)
+        writeSharedCookie(name, value, COOKIE_MAX_AGE)
     }
 
     // nextTick/flush:'post' runs after color-mode's own watcher writes the host-only cookie, to avoid racing it.

--- a/app/store/auth.ts
+++ b/app/store/auth.ts
@@ -1,23 +1,57 @@
 import { defineStore } from 'pinia'
 import type { ProfileInterface } from '@/api/profile'
 import { ref } from '#imports'
+import { type CachedProfile, writeCachedProfile, clearCachedProfile } from '@/utils/profileCookie'
+
+function toCachedProfile(profile: ProfileInterface): CachedProfile {
+    return {
+        v: 1,
+        id: profile.id,
+        name: profile.name,
+        lastName: profile.lastName,
+        nickName: profile.nickName,
+        email: profile.email,
+        photoUrl: profile.photoUrl,
+        isEmailConfirmed: profile.isEmailConfirmed,
+        locale: profile.locale
+    }
+}
 
 export const useAuthStore = defineStore('auth', () => {
     const profile = ref<ProfileInterface | null>(null)
     const isLogged = ref(false)
     const isProfileLoading = ref(true)
 
+    // A confirmed login — refreshes the cshtrkp display cache. Client-only call sites.
     function login(user: ProfileInterface) {
         profile.value = user
         isLogged.value = true
         isProfileLoading.value = false
+        writeCachedProfile(toCachedProfile(user))
     }
 
-    function logout() {
+    // Renders the header signed-in before GET /profile resolves (#147). Runs during SSR too,
+    // so it must never touch the cookie itself.
+    function seedFromCache(cached: CachedProfile) {
+        profile.value = cached
+        isLogged.value = true
+        isProfileLoading.value = false
+    }
+
+    // In-memory only, for load failures that don't prove the session is dead — the cookie
+    // stays so the next successful load can still serve from cache.
+    function reset() {
         profile.value = null
         isLogged.value = false
         isProfileLoading.value = false
     }
 
-    return { isLogged, isProfileLoading, profile, login, logout }
+    // Session is over — logout, or a 401 (refresh failed). The only two cases allowed to
+    // clear the cshtrkp cookie.
+    function logout() {
+        reset()
+        clearCachedProfile()
+    }
+
+    return { isLogged, isProfileLoading, profile, login, seedFromCache, reset, logout }
 })

--- a/app/utils/profileCookie.ts
+++ b/app/utils/profileCookie.ts
@@ -1,0 +1,70 @@
+import { readCookieValue } from './cookies'
+import { writeSharedCookie, deleteSharedCookie } from './sharedCookie'
+
+// Display cache shared with the SPA (frontend/src/shared/profileCookie.ts). Never an auth signal.
+export const PROFILE_COOKIE = 'cshtrkp'
+
+// 7 days — outlives the ~6.6 day refresh token, so the cache dies with the session.
+const PROFILE_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+
+const SCHEMA_VERSION = 1
+
+export interface CachedProfile {
+    v: 1
+    id: number
+    name: string
+    lastName: string | null
+    nickName: string
+    email: string
+    photoUrl: string | null
+    isEmailConfirmed: boolean
+    locale: string
+}
+
+function isCachedProfile(value: unknown): value is CachedProfile {
+    if (!value || typeof value !== 'object') {
+        return false
+    }
+
+    const d = value as Record<string, unknown>
+    return (
+        d.v === SCHEMA_VERSION
+        && typeof d.id === 'number'
+        && typeof d.name === 'string'
+        && (d.lastName === null || typeof d.lastName === 'string')
+        && typeof d.nickName === 'string'
+        && typeof d.email === 'string'
+        && (d.photoUrl === null || typeof d.photoUrl === 'string')
+        && typeof d.isEmailConfirmed === 'boolean'
+        && typeof d.locale === 'string'
+    )
+}
+
+// Takes the raw cookie string rather than reading document.cookie, so it works during SSR.
+// Any shape mismatch means "no cache" — must never throw during app startup.
+export function parseCachedProfile(cookieString: string): CachedProfile | null {
+    const raw = readCookieValue(cookieString, PROFILE_COOKIE)
+    if (!raw) {
+        return null
+    }
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(raw)
+    }
+    catch {
+        return null
+    }
+
+    return isCachedProfile(parsed) ? parsed : null
+}
+
+export function writeCachedProfile(profile: CachedProfile) {
+    writeSharedCookie(PROFILE_COOKIE, JSON.stringify(profile), PROFILE_COOKIE_MAX_AGE)
+}
+
+// Only on logout or a 401 (see store/auth.ts, components/Header.vue). Never on a parse
+// failure or transient error — the apps deploy independently and a valid cache must survive.
+export function clearCachedProfile() {
+    deleteSharedCookie(PROFILE_COOKIE)
+}

--- a/app/utils/sharedCookie.ts
+++ b/app/utils/sharedCookie.ts
@@ -1,0 +1,75 @@
+import { useRuntimeConfig } from '#imports'
+
+// Parent domain shared with the frontend SPA, so cookies scoped to it are readable from
+// both subdomains (cshtrkt theme, cshtrkl locale, cshtrkp profile cache).
+export function parentDomain(): string | null {
+    const config = useRuntimeConfig()
+    const candidates = [config.public.baseUrl, window.location.origin]
+
+    for (const candidate of candidates) {
+        if (!candidate) {
+            continue
+        }
+
+        try {
+            return new URL(candidate).hostname
+        }
+        catch {
+            continue
+        }
+    }
+
+    return null
+}
+
+// localhost/IP can't take a leading-dot Domain cookie — callers fall back to host-only.
+function isDomainScopable(domain: string | null): domain is string {
+    return !!domain && domain !== 'localhost' && !/^[\d.]+$/.test(domain)
+}
+
+export function deleteHostOnlyCookie(name: string) {
+    if (typeof document === 'undefined') {
+        return
+    }
+
+    document.cookie = `${name}=; path=/; max-age=0`
+}
+
+export function writeSharedCookie(name: string, value: string, maxAge: number) {
+    if (typeof document === 'undefined') {
+        return
+    }
+
+    const domain = parentDomain()
+    const attrs = [
+        `${name}=${encodeURIComponent(value)}`,
+        'path=/',
+        `max-age=${maxAge}`,
+        'SameSite=Lax'
+    ]
+
+    if (isDomainScopable(domain)) {
+        attrs.push(`Domain=.${domain}`)
+    }
+
+    if (window.location.protocol === 'https:') {
+        attrs.push('Secure')
+    }
+
+    document.cookie = attrs.join('; ')
+}
+
+// Deletes both forms: per RFC 6265 a delete only matches an exact (name, domain, path),
+// so a domain-scoped cookie survives a host-only delete.
+export function deleteSharedCookie(name: string) {
+    if (typeof document === 'undefined') {
+        return
+    }
+
+    deleteHostOnlyCookie(name)
+
+    const domain = parentDomain()
+    if (isDomainScopable(domain)) {
+        document.cookie = `${name}=; Domain=.${domain}; path=/; max-age=0`
+    }
+}


### PR DESCRIPTION
## Problem

On first load the header renders signed-out — the login/register links show, then swap for the profile dropdown once `GET /profile` resolves. The same flash happens in the SPA, so the fix is shared between the two apps.

Refs cash-track/frontend#147. SPA side: cash-track/frontend#149.

## Changes

- **`app/utils/profileCookie.ts` (new)** — the `cshtrkp` cookie codec, matching the SPA's byte for byte: same name, same `v: 1` schema (`id`, `name`, `lastName`, `nickName`, `email`, `photoUrl`, `isEmailConfirmed`, `locale`), same 7-day TTL. `parseCachedProfile()` takes the raw cookie string rather than reading `document.cookie`, so it works during SSR. Strict: a missing cookie, non-JSON, a wrong `v` or any wrong-typed field means "no cache" and never throws.
- **`app/components/Header.vue`** — parses the cookie once from the request's `Cookie` header via `useState`, so the header is already signed-in in the SSR HTML and hydration has nothing to swap. Same resolve-once/hydrate pattern the fresh-visitor locale check already uses.
- **`app/store/auth.ts`** — `seedFromCache()` (SSR-safe, in-memory only), `login()` refreshes the cookie, `reset()` drops UI state only, `logout()` also clears the cookie.
- **Clearing is deliberately narrow** — logout, or a 401 that reached the client. A 401 only reaches the client when the gateway's own token refresh failed (a transient refresh problem surfaces as a 503 with cookies untouched), so it is proof the session is dead. Any other profile-load failure calls `reset()` and leaves the cookie for the next successful load.
- **`app/utils/sharedCookie.ts` (new)** — the domain-scoping logic moved out of `app/plugins/shared-cookies.client.ts` so the theme (`cshtrkt`), locale (`cshtrkl`) and profile (`cshtrkp`) cookies share one implementation. `deleteSharedCookie()` issues both the host-only and the domain-scoped delete, since per RFC 6265 a delete matches on exact (name, domain, path). No behaviour change for theme/locale.
- **`app/api/profile.ts`** — `lastName` typed `string | null` to match the API contract.

## Verification

Reviewed against the requirements over three rounds until the reviewer had nothing material left to raise.

**Browser (dev stack):** the SSR HTML contains the cached display name on first paint, and does not when the `cshtrkp` cookie is removed — proving the cookie is the source and there is no flash. The cookie written by the SPA is read by this app with the same profile id, and vice versa.

`npm run lint:js` and `npm run build` clean, re-run after rebasing onto current `master` (which also touches `Header.vue`).